### PR TITLE
dlna: add ogg video/audio rules

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -91,6 +91,10 @@ define([CHECK_MODULE_GENERIC],
         AC_LMS_CHECK_PKG(GENERIC, [libavcodec libavformat], [], [GENERIC=false])
 ])
 
+AC_CHECK_HEADERS([magic.h], [], [AC_MSG_ERROR([libmagic magic.h header file not found])])
+AC_CHECK_LIB([magic], [magic_open], [AC_SUBST([LIBMAGIC], [-lmagic])],
+             [AC_MSG_ERROR([libmagic library or magic_open function not found])], [-lz])
+
 # plugins declarations
 AC_LMS_OPTIONAL_MODULE([dummy], true)
 AC_LMS_OPTIONAL_MODULE([jpeg], true)

--- a/src/lib/Makefile.am
+++ b/src/lib/Makefile.am
@@ -2,7 +2,7 @@ MAINTAINERCLEANFILES = Makefile.in
 
 AM_CPPFLAGS = -include $(top_builddir)/config.h \
 		-I$(top_srcdir)/src/lib @SQLITE3_CFLAGS@
-AM_CFLAGS = $(WARNINGFLAGS)
+AM_CFLAGS = $(WARNINGFLAGS) $(LIBMAGIC)
 AM_LDFLAGS = $(GCLDFLAGS)
 
 include_HEADERS = \

--- a/src/lib/lightmediascanner_db.h
+++ b/src/lib/lightmediascanner_db.h
@@ -116,7 +116,7 @@ extern "C" {
     API lms_db_audio_t *lms_db_audio_new(sqlite3 *db) GNUC_NON_NULL(1);
     API int lms_db_audio_start(lms_db_audio_t *lda) GNUC_NON_NULL(1);
     API int lms_db_audio_free(lms_db_audio_t *lda) GNUC_NON_NULL(1);
-    API int lms_db_audio_add(lms_db_audio_t *lda, struct lms_audio_info *info) GNUC_NON_NULL(1, 2);
+    API int lms_db_audio_add(lms_db_audio_t *lda, struct lms_audio_info *info, const char *path) GNUC_NON_NULL(1, 2);
 
     /* Video Records */
 
@@ -171,7 +171,7 @@ extern "C" {
     API lms_db_video_t *lms_db_video_new(sqlite3 *db) GNUC_NON_NULL(1);
     API int lms_db_video_start(lms_db_video_t *ldv) GNUC_NON_NULL(1);
     API int lms_db_video_free(lms_db_video_t *ldv) GNUC_NON_NULL(1);
-    API int lms_db_video_add(lms_db_video_t *ldv, struct lms_video_info *info) GNUC_NON_NULL(1, 2);
+    API int lms_db_video_add(lms_db_video_t *ldv, struct lms_video_info *info, const char *path) GNUC_NON_NULL(1, 2);
 
     API int lms_stream_video_info_aspect_ratio_guess(struct lms_stream_video_info *info) GNUC_NON_NULL(1);
 

--- a/src/plugins/asf/asf.c
+++ b/src/plugins/asf/asf.c
@@ -789,7 +789,7 @@ _parse(struct plugin *plugin, struct lms_context *ctxt, const struct lms_file_in
             audio_info.codec = s->base.codec;
         }
 
-        r = lms_db_audio_add(plugin->audio_db, &audio_info);
+        r = lms_db_audio_add(plugin->audio_db, &audio_info, finfo->path);
     } else {
         struct lms_video_info video_info = { };
 
@@ -799,7 +799,7 @@ _parse(struct plugin *plugin, struct lms_context *ctxt, const struct lms_file_in
         video_info.length = info.length;
         video_info.container = _container;
         video_info.streams = (struct lms_stream *) info.streams;
-        r = lms_db_video_add(plugin->video_db, &video_info);
+        r = lms_db_video_add(plugin->video_db, &video_info, finfo->path);
     }
 
 done:

--- a/src/plugins/audio-dummy/audio-dummy.c
+++ b/src/plugins/audio-dummy/audio-dummy.c
@@ -74,7 +74,7 @@ _parse(struct plugin *plugin, struct lms_context *ctxt, const struct lms_file_in
     lms_charset_conv(ctxt->cs_conv, &info.title.str, &info.title.len);
 
     info.id = finfo->id;
-    r = lms_db_audio_add(plugin->audio_db, &info);
+    r = lms_db_audio_add(plugin->audio_db, &info, finfo->path);
 
     free(info.title.str);
 

--- a/src/plugins/flac/flac.c
+++ b/src/plugins/flac/flac.c
@@ -143,7 +143,7 @@ title_fallback:
 #endif
 
     info.id = finfo->id;
-    r = lms_db_audio_add(plugin->audio_db, &info);
+    r = lms_db_audio_add(plugin->audio_db, &info, finfo->path);
 
     free(info.title.str);
     free(info.artist.str);

--- a/src/plugins/generic/generic.c
+++ b/src/plugins/generic/generic.c
@@ -529,7 +529,7 @@ _parse(struct plugin *plugin, struct lms_context *ctxt, const struct lms_file_in
         video_info.container = container;
         video_info.packet_size = packet_size;
 
-        ret = lms_db_video_add(plugin->video_db, &video_info);
+        ret = lms_db_video_add(plugin->video_db, &video_info, finfo->path);
     } else {
         audio_info.id = finfo->id;
         audio_info.title = info.title;
@@ -538,7 +538,7 @@ _parse(struct plugin *plugin, struct lms_context *ctxt, const struct lms_file_in
         audio_info.genre = info.genre;
         audio_info.container = container;
 
-        ret = lms_db_audio_add(plugin->audio_db, &audio_info);
+        ret = lms_db_audio_add(plugin->audio_db, &audio_info, finfo->path);
         lms_string_size_strip_and_free(&audio_info.codec);
     }
 

--- a/src/plugins/id3/id3.c
+++ b/src/plugins/id3/id3.c
@@ -1228,7 +1228,7 @@ _parse(struct plugin *plugin, struct lms_context *ctxt, const struct lms_file_in
     _parse_mpeg_header(fd, sync_offset, &audio_info, finfo->size);
 
     audio_info.container = _container_mp3;
-    r = lms_db_audio_add(plugin->audio_db, &audio_info);
+    r = lms_db_audio_add(plugin->audio_db, &audio_info, finfo->path);
 
   done:
     posix_fadvise(fd, 0, 0, POSIX_FADV_DONTNEED);

--- a/src/plugins/mp4/mp4.c
+++ b/src/plugins/mp4/mp4.c
@@ -685,14 +685,14 @@ _parse(struct plugin *plugin, struct lms_context *ctxt, const struct lms_file_in
         audio_info.container = _get_container(mp4_fh);
         audio_info.trackno = info.trackno;
 
-        r = lms_db_audio_add(plugin->audio_db, &audio_info);
+        r = lms_db_audio_add(plugin->audio_db, &audio_info, finfo->path);
     } else {
         video_info.id = finfo->id;
         video_info.title = info.title;
         video_info.artist = info.artist;
         video_info.container = _get_container(mp4_fh);
 
-        r = lms_db_video_add(plugin->video_db, &video_info);
+        r = lms_db_video_add(plugin->video_db, &video_info, finfo->path);
     }
 
 fail:

--- a/src/plugins/ogg/ogg.c
+++ b/src/plugins/ogg/ogg.c
@@ -522,7 +522,7 @@ _parse(struct plugin *plugin, struct lms_context *ctxt,
         audio_info.sampling_rate = info.sampling_rate;
         audio_info.bitrate = info.bitrate;
 
-        r = lms_db_audio_add(plugin->audio_db, &audio_info);
+        r = lms_db_audio_add(plugin->audio_db, &audio_info, finfo->path);
     } else if (info.type == LMS_STREAM_TYPE_VIDEO) {
         struct lms_video_info video_info = { };
 
@@ -531,7 +531,7 @@ _parse(struct plugin *plugin, struct lms_context *ctxt,
         video_info.artist = info.artist;
         video_info.container = _container;
         video_info.streams = (struct lms_stream *) info.streams;
-        r = lms_db_video_add(plugin->video_db, &video_info);
+        r = lms_db_video_add(plugin->video_db, &video_info, finfo->path);
     }
 
 done:

--- a/src/plugins/rm/rm.c
+++ b/src/plugins/rm/rm.c
@@ -475,13 +475,13 @@ _parse(struct plugin *plugin, struct lms_context *ctxt, const struct lms_file_in
         audio_info.id = finfo->id;
         audio_info.title = info.title;
         audio_info.artist = info.artist;
-        r = lms_db_audio_add(plugin->audio_db, &audio_info);
+        r = lms_db_audio_add(plugin->audio_db, &audio_info, finfo->path);
     }
     else {
         video_info.id = finfo->id;
         video_info.title = info.title;
         video_info.artist = info.artist;
-        r = lms_db_video_add(plugin->video_db, &video_info);
+        r = lms_db_video_add(plugin->video_db, &video_info, finfo->path);
     }
 
   done:

--- a/src/plugins/video-dummy/video-dummy.c
+++ b/src/plugins/video-dummy/video-dummy.c
@@ -81,7 +81,7 @@ _parse(struct plugin *plugin, struct lms_context *ctxt, const struct lms_file_in
     lms_charset_conv(ctxt->cs_conv, &info.title.str, &info.title.len);
 
     info.id = finfo->id;
-    r = lms_db_video_add(plugin->video_db, &info);
+    r = lms_db_video_add(plugin->video_db, &info, finfo->path);
 
     free(info.title.str);
 

--- a/src/plugins/wave/wave.c
+++ b/src/plugins/wave/wave.c
@@ -234,7 +234,7 @@ _parse(struct plugin *plugin, struct lms_context *ctxt,
 
     info.id = finfo->id;
 
-    r = lms_db_audio_add(plugin->audio_db, &info);
+    r = lms_db_audio_add(plugin->audio_db, &info, finfo->path);
 
 done:
     posix_fadvise(fd, 0, 0, POSIX_FADV_DONTNEED);


### PR DESCRIPTION
Our dlna rules are based on gupnp ones, gupnp doesn't provide any rules
for ogg, with that we could not provide dlna profile and mime for ogg
audio and video files.

I've researched other dlna servers/providers and found they're using
OGG and OGV for profile also audio/ogg and video/ogg respectively for
audio and video profile and mimetypes.

This patch applies dlna rules based on container information.