### PR TITLE
dlna: implement a mime type selector fallback

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -91,6 +91,17 @@ define([CHECK_MODULE_GENERIC],
         AC_LMS_CHECK_PKG(GENERIC, [libavcodec libavformat], [], [GENERIC=false])
 ])
 
+AC_ARG_ENABLE([magic],
+        [AC_HELP_STRING([--disable-magic],
+                [Disable mime computation with libmagic. @<:@default=enable@:>@])],
+        [enable_magic=${enableval}], [enable_magic=yes])
+
+if test "$enable_magic" = "yes"; then
+   AC_CHECK_HEADERS([magic.h], [], [AC_MSG_ERROR([libmagic magic.h header file not found])])
+   AC_CHECK_LIB([magic], [magic_open], [AC_SUBST([LIBMAGIC], [-lmagic])],
+                [AC_MSG_ERROR([libmagic library or magic_open function not found])], [-lz])
+fi
+
 # plugins declarations
 AC_LMS_OPTIONAL_MODULE([dummy], true)
 AC_LMS_OPTIONAL_MODULE([jpeg], true)
@@ -224,3 +235,4 @@ SUMMARY_EOF
 
 echo -e " * modules........: $MODS $UNUSED_MODS"
 echo -e " * daemon.........: ${build_daemon}"
+echo -e " * use libmagic...: ${enable_magic}"

--- a/src/bin/lightmediascannerd.c
+++ b/src/bin/lightmediascannerd.c
@@ -656,6 +656,7 @@ scan_progress_cb(lms_t *lms, const char *path, int pathlen, lms_progress_status_
     case LMS_PROGRESS_STATUS_DELETED:
         sp->deleted++;
         break;
+    case LMS_PROGRESS_STATUS_UNKNOWN:
     case LMS_PROGRESS_STATUS_KILLED:
     case LMS_PROGRESS_STATUS_ERROR_PARSE:
     case LMS_PROGRESS_STATUS_ERROR_COMM:

--- a/src/lib/Makefile.am
+++ b/src/lib/Makefile.am
@@ -30,4 +30,4 @@ liblightmediascanner_la_SOURCES = \
 	lightmediascanner_dlna.c
 
 liblightmediascanner_la_LIBADD = -ldl @SQLITE3_LIBS@ @LTLIBICONV@
-liblightmediascanner_la_LDFLAGS = -version-info @version_info@
+liblightmediascanner_la_LDFLAGS = -version-info @version_info@ @LIBMAGIC@

--- a/src/lib/lightmediascanner_dlna.h
+++ b/src/lib/lightmediascanner_dlna.h
@@ -19,7 +19,9 @@
  * @author Leandro Dorileo <leandro.maciel.dorileo@intel.com>
  */
 
+#include "lightmediascanner.h"
 #include <lightmediascanner_db.h>
+#include <lightmediascanner_private.h>
 #include <stdio.h>
 #include <math.h>
 
@@ -66,6 +68,76 @@
 
 #define DLNA_VIDEO_FRAMERATE_RANGE(_min, _max)                          \
     &(struct dlna_video_framerate_range) {.min = _min, .max = _max}     \
+
+#ifdef HAVE_MAGIC_H
+
+#define LMS_DLNA_GET_PROFILE_PATH_FB(_info, _type, _dlna, _path)        \
+    do {                                                                \
+        if ((_info)->dlna_mime.len == 0 &&                              \
+            (_info)->dlna_profile.len == 0) {                           \
+            _dlna = lms_dlna_get_##_type##_profile(_info);              \
+            if (_dlna) {                                                \
+                (_info)->dlna_mime = *_dlna->dlna_mime;                 \
+                (_info)->dlna_profile = *_dlna->dlna_profile;           \
+            }                                                           \
+        }                                                               \
+        if ((_info)->dlna_mime.len == 0)                                \
+            lms_mime_type_get_from_path(_path, &(_info)->dlna_mime);    \
+    } while(0)                                                          \
+
+#define LMS_DLNA_GET_VIDEO_PROFILE_PATH_FB(_info, _dlna, _path)         \
+    LMS_DLNA_GET_PROFILE_PATH_FB(_info, video, _dlna, _path)            \
+
+#define LMS_DLNA_GET_AUDIO_PROFILE_PATH_FB(_info, _dlna, _path)         \
+    LMS_DLNA_GET_PROFILE_PATH_FB(_info, audio, _dlna, _path)            \
+
+#define LMS_DLNA_GET_IMAGE_PROFILE_PATH_FB(_info, _dlna, _path)         \
+    LMS_DLNA_GET_PROFILE_PATH_FB(_info, image, _dlna, _path)            \
+
+#define LMS_DLNA_GET_PROFILE_FD_FB(_info, _type, _dlna, _fd)            \
+    do {                                                                \
+        if ((_info)->dlna_mime.len == 0 &&                              \
+            (_info)->dlna_profile.len == 0) {                           \
+            _dlna = lms_dlna_get_##_type##_profile(_info);              \
+            if (_dlna) {                                                \
+                (_info)->dlna_mime = *_dlna->dlna_mime;                 \
+                (_info)->dlna_profile = *_dlna->dlna_profile;           \
+            }                                                           \
+        }                                                               \
+        if ((_info)->dlna_mime.len == 0)                                \
+            lms_mime_type_get_from_fd(_fd, &(_info)->dlna_mime);        \
+    } while(0)                                                          \
+
+#define LMS_DLNA_GET_VIDEO_PROFILE_FD_FB(_info, _dlna, _fd)             \
+    LMS_DLNA_GET_PROFILE_FD_FB(_info, video, _dlna, _fd)                \
+
+#define LMS_DLNA_GET_AUDIO_PROFILE_FD_FB(_info, _dlna, _fd)             \
+    LMS_DLNA_GET_PROFILE_FD_FB(_info, audio, _dlna, _fd)                \
+
+#define LMS_DLNA_GET_IMAGE_PROFILE_FD_FB(_info, _dlna, _fd)             \
+    LMS_DLNA_GET_PROFILE_FD_FB(_info, image, _dlna, _fd)                \
+
+#else
+
+#define LMS_DLNA_GET_VIDEO_PROFILE_PATH_FB(_info, _dlna, _path)         \
+    do { _dlna = _dlna;} while(0)                                       \
+
+#define LMS_DLNA_GET_AUDIO_PROFILE_PATH_FB(_info, _dlna, _path)         \
+    do { _dlna = _dlna;} while(0)                                       \
+
+#define LMS_DLNA_GET_IMAGE_PROFILE_PATH_FB(_info, _dlna, _path)         \
+    do { _dlna = _dlna;} while(0)                                       \
+
+#define LMS_DLNA_GET_VIDEO_PROFILE_FD_FB(_info, _dlna, _fd)             \
+    do { _dlna = _dlna;} while(0)                                       \
+
+#define LMS_DLNA_GET_AUDIO_PROFILE_FD_FB(_info, _dlna, _fd)             \
+    do { _dlna = _dlna;} while(0)                                       \
+
+#define LMS_DLNA_GET_IMAGE_PROFILE_FD_FB(_info, _dlna, _fd)             \
+    do { _dlna = _dlna;} while(0)                                       \
+
+#endif
 
 struct dlna_bitrate {
     const unsigned int min;
@@ -158,9 +230,9 @@ struct lms_dlna_image_profile {
     const struct lms_dlna_image_rule *image_rule;
 };
 
-const struct lms_dlna_video_profile *lms_dlna_get_video_profile(struct lms_video_info *info);
-const struct lms_dlna_audio_profile *lms_dlna_get_audio_profile(struct lms_audio_info *info);
-const struct lms_dlna_image_profile *lms_dlna_get_image_profile(struct lms_image_info *info);
+API const struct lms_dlna_video_profile *lms_dlna_get_video_profile(struct lms_video_info *info);
+API const struct lms_dlna_audio_profile *lms_dlna_get_audio_profile(struct lms_audio_info *info);
+API const struct lms_dlna_image_profile *lms_dlna_get_image_profile(struct lms_image_info *info);
 
 extern const struct lms_string_size _container_mp3;
 extern const struct lms_string_size _container_mpeg;

--- a/src/lib/lightmediascanner_private.h
+++ b/src/lib/lightmediascanner_private.h
@@ -33,6 +33,7 @@
 
 #include "lightmediascanner.h"
 #include "lightmediascanner_plugin.h"
+#include "lightmediascanner_utils.h"
 #include "lightmediascanner_charset_conv.h"
 #include <sys/types.h>
 #include <poll.h>
@@ -106,6 +107,8 @@ int lms_parsers_start(lms_t *lms, sqlite3 *db) GNUC_NON_NULL(1, 2);
 int lms_parsers_finish(lms_t *lms, sqlite3 *db) GNUC_NON_NULL(1, 2);
 int lms_parsers_check_using(lms_t *lms, void **parser_match, struct lms_file_info *finfo) GNUC_NON_NULL(1, 2, 3);
 int lms_parsers_run(lms_t *lms, sqlite3 *db, void **parser_match, struct lms_file_info *finfo) GNUC_NON_NULL(1, 2, 3, 4);
+API int lms_mime_type_get_from_path(const char *path, struct lms_string_size *mime) GNUC_NON_NULL(1, 2);
+API int lms_mime_type_get_from_fd(int fd, struct lms_string_size *mime) GNUC_NON_NULL(2);
 
 
 #endif /* _LIGHTMEDIASCANNER_PRIVATE_H_ */

--- a/src/plugins/asf/asf.c
+++ b/src/plugins/asf/asf.c
@@ -29,6 +29,7 @@
 
 #include <lightmediascanner_plugin.h>
 #include <lightmediascanner_db.h>
+#include <lightmediascanner_dlna.h>
 #include <shared/util.h>
 
 #include <endian.h>
@@ -686,6 +687,8 @@ _parse(struct plugin *plugin, struct lms_context *ctxt, const struct lms_file_in
     unsigned int size;
     unsigned long long hdrsize;
     off_t pos_end, pos = 0;
+    const struct lms_dlna_video_profile *video_dlna;
+    const struct lms_dlna_audio_profile *audio_dlna;
 
     fd = open(finfo->path, O_RDONLY);
     if (fd < 0) {
@@ -789,6 +792,7 @@ _parse(struct plugin *plugin, struct lms_context *ctxt, const struct lms_file_in
             audio_info.codec = s->base.codec;
         }
 
+        LMS_DLNA_GET_AUDIO_PROFILE_FD_FB(&audio_info, audio_dlna, fd);
         r = lms_db_audio_add(plugin->audio_db, &audio_info);
     } else {
         struct lms_video_info video_info = { };
@@ -799,6 +803,7 @@ _parse(struct plugin *plugin, struct lms_context *ctxt, const struct lms_file_in
         video_info.length = info.length;
         video_info.container = _container;
         video_info.streams = (struct lms_stream *) info.streams;
+        LMS_DLNA_GET_VIDEO_PROFILE_FD_FB(&video_info, video_dlna, fd);
         r = lms_db_video_add(plugin->video_db, &video_info);
     }
 

--- a/src/plugins/flac/flac.c
+++ b/src/plugins/flac/flac.c
@@ -26,6 +26,7 @@
 
 #include <lightmediascanner_plugin.h>
 #include <lightmediascanner_db.h>
+#include <lightmediascanner_dlna.h>
 
 #include <stdio.h>
 #include <stdlib.h>
@@ -73,6 +74,7 @@ _parse(struct plugin *plugin, struct lms_context *ctxt, const struct lms_file_in
     char *str;
     int len, r;
     unsigned int i;
+    const struct lms_dlna_audio_profile *audio_dlna;
 
     if (!FLAC__metadata_get_streaminfo(finfo->path, &si)) {
         fprintf(stderr, "ERROR: cannot retrieve file %s STREAMINFO block\n",
@@ -143,6 +145,7 @@ title_fallback:
 #endif
 
     info.id = finfo->id;
+    LMS_DLNA_GET_AUDIO_PROFILE_PATH_FB(&info, audio_dlna, finfo->path);
     r = lms_db_audio_add(plugin->audio_db, &info);
 
     free(info.title.str);

--- a/src/plugins/generic/generic.c
+++ b/src/plugins/generic/generic.c
@@ -24,6 +24,7 @@
 #include "libavutil/opt.h"
 
 #include <lightmediascanner_db.h>
+#include <lightmediascanner_dlna.h>
 #include <lightmediascanner_plugin.h>
 
 #include <sys/types.h>
@@ -460,6 +461,8 @@ _parse(struct plugin *plugin, struct lms_context *ctxt, const struct lms_file_in
     struct lms_video_info video_info = { };
     struct lms_string_size container = { };
     bool video = false;
+    const struct lms_dlna_video_profile *video_dlna;
+    const struct lms_dlna_audio_profile *audio_dlna;
 
     if (finfo->parsed)
         return 0;
@@ -547,6 +550,8 @@ _parse(struct plugin *plugin, struct lms_context *ctxt, const struct lms_file_in
         video_info.container = container;
         video_info.packet_size = packet_size;
 
+        LMS_DLNA_GET_VIDEO_PROFILE_PATH_FB(&video_info, video_dlna,
+                                           finfo->path);
         ret = lms_db_video_add(plugin->video_db, &video_info);
     } else {
         audio_info.id = finfo->id;
@@ -556,7 +561,10 @@ _parse(struct plugin *plugin, struct lms_context *ctxt, const struct lms_file_in
         audio_info.genre = info.genre;
         audio_info.container = container;
 
+        LMS_DLNA_GET_AUDIO_PROFILE_PATH_FB(&audio_info, audio_dlna,
+                                           finfo->path);
         ret = lms_db_audio_add(plugin->audio_db, &audio_info);
+
         lms_string_size_strip_and_free(&audio_info.codec);
     }
 

--- a/src/plugins/id3/id3.c
+++ b/src/plugins/id3/id3.c
@@ -33,6 +33,7 @@
  *   http://id3.org/id3v2.3.0
  */
 
+#include <lightmediascanner_dlna.h>
 #include <lightmediascanner_plugin.h>
 #include <lightmediascanner_db.h>
 #include <lightmediascanner_charset_conv.h>
@@ -50,8 +51,6 @@
 
 #define DECL_STR(cname, str)                                            \
     static const struct lms_string_size cname = LMS_STATIC_STRING_SIZE(str)
-
-DECL_STR(_container_mp3, "mp3");
 
 DECL_STR(_codec_mpeg1layer1, "mpeg1layer1");
 DECL_STR(_codec_mpeg1layer2, "mpeg1layer2");
@@ -1140,6 +1139,7 @@ _parse(struct plugin *plugin, struct lms_context *ctxt, const struct lms_file_in
     int r, fd;
     long id3v2_offset;
     off_t sync_offset = 0;
+    const struct lms_dlna_audio_profile *audio_dlna;
 
     fd = open(finfo->path, O_RDONLY);
     if (fd < 0) {
@@ -1228,6 +1228,7 @@ _parse(struct plugin *plugin, struct lms_context *ctxt, const struct lms_file_in
     _parse_mpeg_header(fd, sync_offset, &audio_info, finfo->size);
 
     audio_info.container = _container_mp3;
+    LMS_DLNA_GET_AUDIO_PROFILE_FD_FB(&audio_info, audio_dlna, fd);
     r = lms_db_audio_add(plugin->audio_db, &audio_info);
 
   done:

--- a/src/plugins/jpeg/jpeg.c
+++ b/src/plugins/jpeg/jpeg.c
@@ -32,6 +32,7 @@
 #include <lightmediascanner_plugin.h>
 #include <lightmediascanner_utils.h>
 #include <lightmediascanner_db.h>
+#include <lightmediascanner_dlna.h>
 #include <shared/util.h>
 
 #include <sys/types.h>
@@ -610,6 +611,7 @@ _parse(struct plugin *plugin, struct lms_context *ctxt, const struct lms_file_in
 {
     struct lms_image_info info = { };
     int fd, type, len, r;
+    const struct lms_dlna_image_profile *image_dlna;
 
     fd = open(finfo->path, O_RDONLY);
     if (fd < 0) {
@@ -655,6 +657,7 @@ _parse(struct plugin *plugin, struct lms_context *ctxt, const struct lms_file_in
 
     info.container = _container_jpeg;
     info.id = finfo->id;
+    LMS_DLNA_GET_IMAGE_PROFILE_FD_FB(&info, image_dlna, fd);
     r = lms_db_image_add(plugin->img_db, &info);
 
   done:

--- a/src/plugins/mp4/mp4.c
+++ b/src/plugins/mp4/mp4.c
@@ -28,6 +28,7 @@ static const char PV[] = PACKAGE_VERSION; /* mp4.h screws PACKAGE_VERSION */
 
 #include <lightmediascanner_plugin.h>
 #include <lightmediascanner_db.h>
+#include <lightmediascanner_dlna.h>
 
 #include <mp4v2/mp4v2.h>
 #include <string.h>
@@ -577,6 +578,8 @@ _parse(struct plugin *plugin, struct lms_context *ctxt, const struct lms_file_in
     MP4FileHandle mp4_fh;
     u_int32_t num_tracks, i;
     const MP4Tags *tags;
+    const struct lms_dlna_video_profile *video_dlna;
+    const struct lms_dlna_audio_profile *audio_dlna;
 
     mp4_fh = MP4Read(finfo->path);
     if (mp4_fh == MP4_INVALID_FILE_HANDLE) {
@@ -685,6 +688,8 @@ _parse(struct plugin *plugin, struct lms_context *ctxt, const struct lms_file_in
         audio_info.container = _get_container(mp4_fh);
         audio_info.trackno = info.trackno;
 
+        LMS_DLNA_GET_AUDIO_PROFILE_PATH_FB(&audio_info, audio_dlna,
+                                           finfo->path);
         r = lms_db_audio_add(plugin->audio_db, &audio_info);
     } else {
         video_info.id = finfo->id;
@@ -692,6 +697,8 @@ _parse(struct plugin *plugin, struct lms_context *ctxt, const struct lms_file_in
         video_info.artist = info.artist;
         video_info.container = _get_container(mp4_fh);
 
+        LMS_DLNA_GET_VIDEO_PROFILE_PATH_FB(&video_info, video_dlna,
+                                           finfo->path);
         r = lms_db_video_add(plugin->video_db, &video_info);
     }
 

--- a/src/plugins/ogg/ogg.c
+++ b/src/plugins/ogg/ogg.c
@@ -32,6 +32,7 @@
 
 #include <lightmediascanner_plugin.h>
 #include <lightmediascanner_db.h>
+#include <lightmediascanner_dlna.h>
 #include <lightmediascanner_utils.h>
 
 #include <assert.h>
@@ -487,6 +488,8 @@ _parse(struct plugin *plugin, struct lms_context *ctxt,
 {
     struct ogg_info info = { .type = LMS_STREAM_TYPE_UNKNOWN };
     int r;
+    const struct lms_dlna_video_profile *video_dlna;
+    const struct lms_dlna_audio_profile *audio_dlna;
 
     r = _parse_ogg(finfo->path, &info);
     if (r != 0)
@@ -522,6 +525,8 @@ _parse(struct plugin *plugin, struct lms_context *ctxt,
         audio_info.sampling_rate = info.sampling_rate;
         audio_info.bitrate = info.bitrate;
 
+        LMS_DLNA_GET_AUDIO_PROFILE_PATH_FB(&audio_info, audio_dlna,
+                                           finfo->path);
         r = lms_db_audio_add(plugin->audio_db, &audio_info);
     } else if (info.type == LMS_STREAM_TYPE_VIDEO) {
         struct lms_video_info video_info = { };
@@ -531,6 +536,8 @@ _parse(struct plugin *plugin, struct lms_context *ctxt,
         video_info.artist = info.artist;
         video_info.container = _container;
         video_info.streams = (struct lms_stream *) info.streams;
+        LMS_DLNA_GET_VIDEO_PROFILE_PATH_FB(&video_info, video_dlna,
+                                           finfo->path);
         r = lms_db_video_add(plugin->video_db, &video_info);
     }
 

--- a/src/plugins/png/png.c
+++ b/src/plugins/png/png.c
@@ -30,6 +30,7 @@
 #include <lightmediascanner_plugin.h>
 #include <lightmediascanner_utils.h>
 #include <lightmediascanner_db.h>
+#include <lightmediascanner_dlna.h>
 
 #include <sys/types.h>
 #include <sys/stat.h>
@@ -130,6 +131,7 @@ _parse(struct plugin *plugin, struct lms_context *ctxt, const struct lms_file_in
 {
     struct lms_image_info info = { };
     int fd, r;
+    const struct lms_dlna_image_profile *image_dlna;
 
     fd = open(finfo->path, O_RDONLY);
     if (fd < 0) {
@@ -156,6 +158,7 @@ _parse(struct plugin *plugin, struct lms_context *ctxt, const struct lms_file_in
 
     info.id = finfo->id;
     info.container = _container_png;
+    LMS_DLNA_GET_IMAGE_PROFILE_FD_FB(&info, image_dlna, fd);
     r = lms_db_image_add(plugin->img_db, &info);
 
   done:

--- a/src/plugins/rm/rm.c
+++ b/src/plugins/rm/rm.c
@@ -29,6 +29,7 @@
 
 #include <lightmediascanner_plugin.h>
 #include <lightmediascanner_db.h>
+#include <lightmediascanner_dlna.h>
 
 #include <sys/types.h>
 #include <sys/stat.h>
@@ -398,6 +399,8 @@ _parse(struct plugin *plugin, struct lms_context *ctxt, const struct lms_file_in
     char type[4];
     uint32_t size;
     bool has_cont = false, has_prop = false, has_mdpr = false;
+    const struct lms_dlna_video_profile *video_dlna;
+    const struct lms_dlna_audio_profile *audio_dlna;
 
     fd = open(finfo->path, O_RDONLY);
     if (fd < 0) {
@@ -475,12 +478,14 @@ _parse(struct plugin *plugin, struct lms_context *ctxt, const struct lms_file_in
         audio_info.id = finfo->id;
         audio_info.title = info.title;
         audio_info.artist = info.artist;
+        LMS_DLNA_GET_AUDIO_PROFILE_FD_FB(&audio_info, audio_dlna, fd);
         r = lms_db_audio_add(plugin->audio_db, &audio_info);
     }
     else {
         video_info.id = finfo->id;
         video_info.title = info.title;
         video_info.artist = info.artist;
+        LMS_DLNA_GET_VIDEO_PROFILE_FD_FB(&video_info, video_dlna, fd);
         r = lms_db_video_add(plugin->video_db, &video_info);
     }
 

--- a/src/plugins/wave/wave.c
+++ b/src/plugins/wave/wave.c
@@ -35,6 +35,7 @@
 
 #include <lightmediascanner_plugin.h>
 #include <lightmediascanner_db.h>
+#include <lightmediascanner_dlna.h>
 #include <lightmediascanner_charset_conv.h>
 #include <shared/util.h>
 
@@ -215,6 +216,7 @@ _parse(struct plugin *plugin, struct lms_context *ctxt,
 {
     struct lms_audio_info info = { };
     int r, fd;
+    const struct lms_dlna_audio_profile *audio_dlna;
 
     fd = open(finfo->path, O_RDONLY);
     if (fd < 0)
@@ -234,6 +236,7 @@ _parse(struct plugin *plugin, struct lms_context *ctxt,
 
     info.id = finfo->id;
 
+    LMS_DLNA_GET_AUDIO_PROFILE_FD_FB(&info, audio_dlna, fd);
     r = lms_db_audio_add(plugin->audio_db, &info);
 
 done:


### PR DESCRIPTION
Since rygel will always want to have a mime type computed for every
single file in the lms database we must provide one even if it's not a
dlna recognized file.

This patch implements a fallback option, when we can't determine the
mime type based on dlna rules we still try to compute it using libmagic.