### PR TITLE
remove zlib dependency

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -99,7 +99,7 @@ AC_ARG_ENABLE([magic],
 if test "$enable_magic" = "yes"; then
    AC_CHECK_HEADERS([magic.h], [], [AC_MSG_ERROR([libmagic magic.h header file not found])])
    AC_CHECK_LIB([magic], [magic_open], [AC_SUBST([LIBMAGIC], [-lmagic])],
-                [AC_MSG_ERROR([libmagic library or magic_open function not found])], [-lz])
+                [AC_MSG_ERROR([libmagic library or magic_open function not found])])
 fi
 
 # plugins declarations


### PR DESCRIPTION
libmagic doesn't need zlib any more so we don't need to check for it with
ac_check_lib macro. Requiring zlib (an unused dependency) will force us
to install zlib on tizen-ivi, since we don't need/use it we better remove
the explicit dependency from configure.ac.