### PR TITLE
build: support out-of-tree compilation for id3 plugin

### DIFF
--- a/src/plugins/Makefile.am
+++ b/src/plugins/Makefile.am
@@ -93,7 +93,7 @@ pkg_LTLIBRARIES += id3/id3.la
 id3_id3_la_SOURCES = id3/id3.c id3/id3v1_genres.c
 id3_id3_la_LIBADD = $(PLUGINS_LIBADD)
 
-id3/id3v1_genres.c: $(srcdir)/id3/id3v1_genres.def $(srcdir)/id3/id3v1_genres_gen.awk
+$(srcdir)/id3/id3v1_genres.c: $(srcdir)/id3/id3v1_genres.def $(srcdir)/id3/id3v1_genres_gen.awk
 	$(AWK) -f $(srcdir)/id3/id3v1_genres_gen.awk $(srcdir)/id3/id3v1_genres.def > $@
 
 EXTRA_DIST += id3/id3v1_genres.def id3/id3v1_genres_gen.awk


### PR DESCRIPTION
Some build systems, such as Yocto, use a separate directory
to output compilation results.

Creating an id3 source file with gawk using given syntax
will then fail, because the output directory is invalid.
Even if it was, there is a risk for the rest of the process
to fail if it looks for the generated file inside the
source tree instead of the build tree.

Thus, fix this by forcing creation inside the source tree.

Signed-off-by: Manuel Bachmann <manuel.bachmann@iot.bzh>