### PR TITLE
Fix a regression in lms_db_cache_resize

### DIFF
--- a/src/lib/lightmediascanner_db_common.c
+++ b/src/lib/lightmediascanner_db_common.c
@@ -407,7 +407,7 @@ static int
 lms_db_cache_resize(struct lms_db_cache *cache, unsigned int new_size)
 {
     void *tmp = realloc(cache->entries,
-                        cache->size * sizeof(*cache->entries));
+                        new_size * sizeof(*cache->entries));
     if (new_size > 0 && !tmp) {
         perror("realloc");
         return -1;


### PR DESCRIPTION
In commit 85fd21df645dbc519d192fc0ebdb0051134c1fb3,
the assigning of the value of new_size to cache->size was deferred for
more robust error handling. However, cache->size is still used for
size calculation for realloc, not new_size.